### PR TITLE
Fix typo: ToggleConsoleVisiblity to ToggleConsoleVisibility

### DIFF
--- a/addons/deploy_to_steamos/deploy_window/DeployWindow.cs
+++ b/addons/deploy_to_steamos/deploy_window/DeployWindow.cs
@@ -261,7 +261,7 @@ public partial class DeployWindow : Window
 		}
 	}
 
-	private void ToggleConsoleVisiblity(DeployStep step)
+	private void ToggleConsoleVisibility(DeployStep step)
 	{
 		var consoleContainer = step switch
 		{
@@ -287,18 +287,18 @@ public partial class DeployWindow : Window
 
 	public void OnBuildingConsolePressed()
 	{
-		ToggleConsoleVisiblity(DeployStep.Building);
+		ToggleConsoleVisibility(DeployStep.Building);
 	}
 	public void OnPrepareUploadConsolePressed()
 	{
-		ToggleConsoleVisiblity(DeployStep.PrepareUpload);
+		ToggleConsoleVisibility(DeployStep.PrepareUpload);
 	}
 	public void OnUploadingConsolePressed()
 	{
-		ToggleConsoleVisiblity(DeployStep.Uploading);
+		ToggleConsoleVisibility(DeployStep.Uploading);
 	}
 	public void OnCreatingShortcutConsolePressed()
 	{
-		ToggleConsoleVisiblity(DeployStep.CreateShortcut);
+		ToggleConsoleVisibility(DeployStep.CreateShortcut);
 	}
 }


### PR DESCRIPTION
Hello!

I was working on some warnings in my project and VS2022 alerted on the spelling of this private method. No public API changes, only change made is class-specific.

Thanks for the project!